### PR TITLE
appdata: Fix appdata papercuts

### DIFF
--- a/resources/com.powerball253.eternalmodmanager.appdata.xml
+++ b/resources/com.powerball253.eternalmodmanager.appdata.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2023 PowerBall253 -->
-<component type="desktop">
+<component type="desktop-application">
   <id>com.powerball253.eternalmodmanager</id>
   <launchable type="desktop-id">com.powerball253.eternalmodmanager.desktop</launchable>
   <name>EternalModManager</name>
   <project_license>MIT</project_license>
   <developer_name>PowerBall253</developer_name>
-  <summary>Cross platform mod manager for DOOM Eternal.</summary>
+  <developer id="io.github.powerball253">
+    <name>PowerBall253</name>
+  </developer>
+  <summary>Cross platform mod manager for DOOM Eternal</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <url type="homepage">https://github.com/PowerBall253/EternalModManager</url>
   <url type="help">https://github.com/PowerBall253/EternalModManager/issues</url>
   <url type="bugtracker">https://github.com/PowerBall253/EternalModManager/issues</url>
+  <url type="vcs-browser">https://github.com/PowerBall253/EternalModManager</url>
   <description>
     <p>A cross platform mod manager for DOOM Eternal, making it easier to set-up and install mods in both Windows and Linux.</p>
   </description>

--- a/resources/com.powerball253.eternalmodmanager.appdata.xml
+++ b/resources/com.powerball253.eternalmodmanager.appdata.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2023 PowerBall253 -->
+<!-- Copyright 2023 Bruno Ancona -->
 <component type="desktop-application">
   <id>com.powerball253.eternalmodmanager</id>
   <launchable type="desktop-id">com.powerball253.eternalmodmanager.desktop</launchable>
   <name>EternalModManager</name>
   <project_license>MIT</project_license>
-  <developer_name>PowerBall253</developer_name>
-  <developer id="io.github.powerball253">
-    <name>PowerBall253</name>
+  <developer_name>Bruno Ancona</developer_name>
+  <developer id="io.github.brunoanc">
+    <name>Bruno Ancona</name>
   </developer>
   <summary>Cross platform mod manager for DOOM Eternal</summary>
   <metadata_license>CC0-1.0</metadata_license>
-  <url type="homepage">https://github.com/PowerBall253/EternalModManager</url>
-  <url type="help">https://github.com/PowerBall253/EternalModManager/issues</url>
-  <url type="bugtracker">https://github.com/PowerBall253/EternalModManager/issues</url>
-  <url type="vcs-browser">https://github.com/PowerBall253/EternalModManager</url>
+  <url type="homepage">https://github.com/brunoanc/EternalModManager</url>
+  <url type="help">https://github.com/brunoanc/EternalModManager/issues</url>
+  <url type="bugtracker">https://github.com/brunoanc/EternalModManager/issues</url>
+  <url type="vcs-browser">https://github.com/brunoanc/EternalModManager</url>
   <description>
     <p>A cross platform mod manager for DOOM Eternal, making it easier to set-up and install mods in both Windows and Linux.</p>
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://github.com/PowerBall253/EternalModManager/raw/main/screenshots/main_window.png</image>
+      <image type="source">https://github.com/brunoanc/EternalModManager/raw/main/screenshots/main_window.png</image>
     </screenshot>
     <screenshot>
-      <image type="source">https://github.com/PowerBall253/EternalModManager/raw/main/screenshots/advanced_window.png</image>
+      <image type="source">https://github.com/brunoanc/EternalModManager/raw/main/screenshots/advanced_window.png</image>
     </screenshot>
     <screenshot>
-      <image type="source">https://github.com/PowerBall253/EternalModManager/raw/main/screenshots/main_window_light.png</image>
+      <image type="source">https://github.com/brunoanc/EternalModManager/raw/main/screenshots/main_window_light.png</image>
     </screenshot>
     <screenshot>
-      <image type="source">https://github.com/PowerBall253/EternalModManager/raw/main/screenshots/advanced_window_light.png</image>
+      <image type="source">https://github.com/brunoanc/EternalModManager/raw/main/screenshots/advanced_window_light.png</image>
     </screenshot>
   </screenshots>
   <releases>
@@ -84,5 +84,5 @@
     <release version="1.0.0" date="2021-07-06"/>
   </releases>
   <content_rating type="oars-1.1" />
-  <update_contact>bruno@powerball253.com</update_contact>
+  <update_contact>brunoancolasala@gmail.com</update_contact>
 </component>


### PR DESCRIPTION
- Use `desktop-application` as the component type
- Add developer block with `io.github.powerball253` ID
- Remove the full stop from the summary
- Add VCS-browser URL to show the source code repository

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/